### PR TITLE
Two Astrogator Plugins Added

### DIFF
--- a/StkUiPlugins/VB/Astrogator_ConstantSlewManeuverPlugin/Constant Rates Attitude Controller.xml
+++ b/StkUiPlugins/VB/Astrogator_ConstantSlewManeuverPlugin/Constant Rates Attitude Controller.xml
@@ -1,0 +1,48 @@
+<?xml version = "1.0"?>
+
+<!--
+      AGI Registry File for COM Servers. 
+-->
+
+<AGIRegistry version = "1.0">
+
+	<CategoryRegistry>
+		
+		<Category Name = "Attitude Controls">
+				
+			<!-- This tag to the left indicates the start of a comment block
+
+				Register your plugins with those below. Use the following format:
+
+				<Plugin DisplayName = "YOUR_NAME_TO_APPEAR_IN_USER_INTERFACE_GOES_HERE" ProgID = "YOUR_PROGID_GOES_HERE"/>
+
+				The tag below indicates the end of the comment block 
+			-->
+			
+			<!-- NOTE: The xml reader is case sensitive, so while the keyword ProgID is valid, 
+					   ProgId is invalid because of the 'd' not being capitalized. 
+					   Any improper keyword casing violation will cause the plugin to 
+					   not be registered.
+			-->
+
+            <!-- This section is a comment block.
+			
+			The following Plugin tags register each Plugin component as an Attitude Controller Plugin. 
+			
+			To enable one of the sample plugins in STK, simply build the component (if necessary), 
+			register it in the Windows Registry, and move the registration line below 
+			outside of this comment block.
+
+			<Plugin DisplayName = "JScript AttCtrl Example" ProgID = "JScript.Example1.AttitudeController.WSC"/>
+			<Plugin DisplayName = "CSharp AttCtrl Example" ProgID = "AGI.Astrogator.Plugin.Examples.AttitudeControl.CSharp.Example1"/>
+			<Plugin DisplayName = "CPP AttCtrl Example" ProgID = "AGI.Astrogator.Plugin.Examples.AttitudeControl.CPP.Example1"/>
+			<Plugin DisplayName = "Matlab AttCtrl Example" ProgID = "Matlab.Example1.AttitudeController.WSC"/>
+			
+             -->
+			<Plugin DisplayName = "VBScript Constant Rates Attitude Controller" ProgID = "VBScript.ConstantRates.AttitudeController.WSC"/>
+
+		</Category>
+		
+	</CategoryRegistry>
+
+</AGIRegistry>

--- a/StkUiPlugins/VB/Astrogator_ConstantSlewManeuverPlugin/ReadMe.txt
+++ b/StkUiPlugins/VB/Astrogator_ConstantSlewManeuverPlugin/ReadMe.txt
@@ -1,0 +1,7 @@
+This plugin allows a user to specify constant angular rates for Yaw, Pitch, and Roll to be executed during a finite maneuver in Astrogator.
+
+This plugin must be registered following the steps from this FAQ: https://agiweb.secure.force.com/faqs/articles/HowTo/Register-wsc-plugin
+
+Once the plugin is registered, boot up STK, create an Astrogate satellite with a finite maneuver, change the "Attitude Control" to "Plugin" 
+and select "VBScript Constant Rates Attitude Controller". 
+

--- a/StkUiPlugins/VB/Astrogator_ConstantSlewManeuverPlugin/VBScript.ConstantRates.AttitudeController.vbs
+++ b/StkUiPlugins/VB/Astrogator_ConstantSlewManeuverPlugin/VBScript.ConstantRates.AttitudeController.vbs
@@ -1,0 +1,351 @@
+'======================================================
+'  Copyright 2012, Analytical Graphics, Inc.          
+' =====================================================
+
+'===========================================
+' AgEAttrAddFlags Enumeration
+'===========================================
+Dim eFlagNone, eFlagTransparent, eFlagHidden, eFlagTransient, eFlagReadOnly, eFlagFixed
+
+eFlagNone			= 0
+eFlagTransparent	= 2
+eFlagHidden			= 4
+eFlagTransient		= 8  
+eFlagReadOnly		= 16
+eFlagFixed			= 32
+
+'==================================
+' Log Msg Type Enumeration
+'==================================
+Dim eLogMsgDebug, eLogMsgInfo, eLogMsgForceInfo, eLogMsgWarning, eLogMsgAlarm
+
+eLogMsgDebug	 	= 0
+eLogMsgInfo 		= 1
+eLogMsgForceInfo 	= 2
+eLogMsgWarning 		= 3
+eLogMsgAlarm 		= 4
+
+'==========================================
+' AgETimeScale
+'==========================================
+Dim eSTKEpochSec
+eSTKEpochSec = 4
+
+'================================
+' Declare Global Variables
+'================================
+Dim m_AgUtPluginSite
+Dim m_CrdnPluginProvider
+Dim m_CrdnConfiguredAxes
+Dim m_AgAttrScope
+Dim m_InitTime
+Dim m_gatorPrv
+Dim m_argOfLat
+
+Set m_AgUtPluginSite = Nothing
+Set m_AgAttrScope	 = Nothing
+
+'======================================
+' Declare Global 'Attribute' Variables
+'======================================
+Dim m_Name
+Dim m_yaw
+Dim m_yawRate
+Dim m_pitch
+Dim m_pitchRate
+Dim m_roll
+Dim m_rollRate
+Dim m_refAxes
+
+'Set default values for this plugins user inputs
+m_Name		= "VBScript.ConstantRates.AttitudeController.wsc"   
+m_yaw		= 0.0
+m_yawRate	= 0.0
+m_pitch		= 0.0
+m_pitchRate	= 0.0
+m_roll		= 0.0
+m_rollRate	= 0.0
+m_refAxes = "VNC"
+
+'=======================
+' GetPluginConfig method - this will create the custom user inputs for this plugin which show up in STK
+'=======================
+Function GetPluginConfig( AgAttrBuilder )
+
+	If( m_AgAttrScope is Nothing ) Then
+   
+		Set m_AgAttrScope = AgAttrBuilder.NewScope()
+		
+		'===========================
+		' General Plugin attributes
+		'===========================
+		Call AgAttrBuilder.AddStringDispatchProperty( m_AgAttrScope, "PluginName", "Human readable plugin name or alias", "Name", eFlagReadOnly )
+				
+		'===========================
+		' Propagation related
+		'===========================
+		Call AgAttrBuilder.AddQuantityDispatchProperty2  ( m_AgAttrScope, "Yaw", "Initial Yaw Offset", "Yaw", "AngleUnit", "Radians", "Radians", 0 )
+		Call AgAttrBuilder.AddQuantityDispatchProperty2  ( m_AgAttrScope, "YawRate", "Yaw Rate (per sec)", "YawRate", "AngleUnit", "Radians", "Radians", 0 )
+		Call AgAttrBuilder.AddQuantityDispatchProperty2  ( m_AgAttrScope, "Pitch", "Initial Pitch Offset", "Pitch", "AngleUnit", "Radians", "Radians", 0 )
+		Call AgAttrBuilder.AddQuantityDispatchProperty2  ( m_AgAttrScope, "PitchRate", "Pitch Rate (per sec)", "PitchRate", "AngleUnit", "Radians", "Radians", 0 )
+		Call AgAttrBuilder.AddQuantityDispatchProperty2  ( m_AgAttrScope, "Roll", "Initial Roll Offset", "Roll", "AngleUnit", "Radians", "Radians", 0 )
+		Call AgAttrBuilder.AddQuantityDispatchProperty2  ( m_AgAttrScope, "RollRate", "Roll Rate (per sec)", "RollRate", "AngleUnit", "Radians", "Radians", 0 )
+		Call AgAttrBuilder.AddStringDispatchProperty( m_AgAttrScope, "RefAxes", "Reference Axes", "RefAxes", 0 )
+
+	End If
+
+	Set GetPluginConfig = m_AgAttrScope
+
+End Function  
+
+'===========================
+' VerifyPluginConfig method - can be used to verify that inputs are valid, but not really used here
+'===========================
+Function VerifyPluginConfig(AgUtPluginConfigVerifyResult)
+   
+    Dim Result
+    Dim Message
+
+	Result = true
+	Message = "Ok"
+
+	AgUtPluginConfigVerifyResult.Result  = Result
+	AgUtPluginConfigVerifyResult.Message = Message
+
+End Function  
+
+'===========================
+' Message method - helper function so other parts of the plugin can easily send something to the STK Message Viewer
+'===========================
+Sub Message( msgType, msg )
+   
+	If( Not m_AgUtPluginSite is Nothing) then
+	   	
+		Call m_AgUtPluginSite.Message( msgType, msg )
+
+	End If
+   	
+End Sub
+
+'======================
+' Init Method - called at the beginning of the MCS evaluation
+'======================
+Function Init( AgUtPluginSite )
+
+	Init = 1
+            
+End Function
+
+'======================
+' PrePropagate Method - called before running the propagate (or finite maneuver) segment which uses this plugin
+'======================
+Function PrePropagate( AgGatorPluginResultAttCtrl )
+
+	If( Not AgGatorPluginResultAttCtrl is Nothing) then
+
+		'Set the reference axes that will be used to define the attitude rotations
+		Message eLogMsgInfo, "m_refAxes: " & m_refAxes
+		Call AgGatorPluginResultAttCtrl.SetRefAxes(m_refAxes)
+
+		'Set a global variable which holds the initial time (in EpSec) of the start of the segment. Will be used as a reference in the Evaluate method.
+		Dim dcArray
+		dcArray = AgGatorPluginResultAttCtrl.DayCount_Array( eStkEpochSec )
+		If(IsArray(dcArray) and UBound(dcArray) > 0) Then
+			m_InitTime = dcArray(0) * 86400.0 + dcArray(1)
+		End If
+
+		'dateArray = AgGatorPluginResultAttCtrl.Date_Array(0)	
+		'Message eLogMsgInfo, "Burn start time: " & dateArray(0) & "-" & dateArray(1) & "-" & dateArray(2) & " " & dateArray(3) & ":" & dateArray(4) & ":" & dateArray(5)
+		'Message eLogMsgInfo, "Burn start time (EpSec): " & m_InitTime
+	End If
+
+	PrePropagate = 1
+
+End Function
+
+'======================
+' PreNextStep Function - called before each propagator step
+'======================
+Function PreNextStep( AgGatorPluginResultAttCtrl )
+
+	PreNextStep = 1
+	
+End Function
+
+'=================
+' Evaluate Method - called during each force model evaluation
+'=================
+Function Evaluate( AgGatorPluginResultAttCtrl )
+
+	If( Not AgGatorPluginResultAttCtrl is Nothing) then
+         
+			Dim time
+			Dim yawAngle
+			Dim pitchAngle
+			Dim rollAngle			
+			Dim deltaT
+			Dim dcArray
+			Dim dateArray
+			
+			time = m_InitTime
+			
+			'Get the current time at this evaluation
+			dcArray = AgGatorPluginResultAttCtrl.DayCount_Array( eStkEpochSec )
+			If(IsArray(dcArray) and UBound(dcArray) > 0) Then
+ 				time = dcArray(0) * 86400.0 + dcArray(1)
+ 			End If
+						
+			deltaT = time - m_InitTime
+			yawAngle = m_yaw + m_yawRate * deltaT
+			pitchAngle = m_pitch + m_pitchRate * deltaT
+			rollAngle = m_roll + m_rollRate * deltaT
+			Call AgGatorPluginResultAttCtrl.EulerRotate( 321, yawAngle, pitchAngle, rollAngle )
+			
+	End If
+         
+        Evaluate = 1
+
+End Function
+
+'======================
+' PostPropagate Method - called after the propagation has finished
+'======================
+Function PostPropagate(resultInterface)
+      
+	PostPropagate = 0
+       	
+End Function
+
+'=================
+' Free Method - called after the entire MCS finishes running
+'=================
+Sub Free()
+
+	' do nothing
+        
+End Sub
+    
+
+'******************
+'Begin Property functions which allow STK to interact with the custom user inputs in this plugin
+'******************
+
+'==================
+' Name property
+'==================
+Function GetName()
+
+	GetName = m_Name
+
+End function
+
+'==================
+' Pitch property
+'==================
+Function GetYaw()
+
+       GetYaw = m_yaw
+
+End Function
+
+Function SetYaw( yaw )
+
+       m_yaw = yaw
+
+End Function
+
+'==================
+' PitchRate property
+'==================
+Function GetYawRate()
+
+       GetYawRate = m_yawRate
+
+End Function
+
+Function SetYawRate( yawRate )
+
+       m_yawRate = yawRate
+
+End Function
+
+'==================
+' Pitch property
+'==================
+Function GetPitch()
+
+       GetPitch = m_pitch
+
+End Function
+
+Function SetPitch( pitch )
+
+       m_pitch = pitch
+
+End Function
+
+'==================
+' PitchRate property
+'==================
+Function GetPitchRate()
+
+       GetPitchRate = m_pitchRate
+
+End Function
+
+Function SetPitchRate( pitchRate )
+
+       m_pitchRate = pitchRate
+
+End Function
+
+'==================
+' Pitch property
+'==================
+Function GetRoll()
+
+       GetRoll = m_roll
+
+End Function
+
+Function SetRoll( roll )
+
+       m_roll = roll
+
+End Function
+
+'==================
+' PitchRate property
+'==================
+Function GetRollRate()
+
+       GetRollRate = m_rollRate
+
+End Function
+
+Function SetRollRate( rollRate )
+
+       m_rollRate = rollRate
+
+End Function
+
+'==================
+' RefAxes property
+'==================
+Function GetRefAxes()
+
+       GetRefAxes = m_refAxes
+
+End Function
+
+Function SetRefAxes( refAxes )
+
+       m_refAxes = refAxes
+
+End Function
+
+
+
+'======================================================
+'  Copyright 2012, Analytical Graphics, Inc.          
+' =====================================================

--- a/StkUiPlugins/VB/Astrogator_ConstantSlewManeuverPlugin/VBScript.ConstantRates.AttitudeController.wsc
+++ b/StkUiPlugins/VB/Astrogator_ConstantSlewManeuverPlugin/VBScript.ConstantRates.AttitudeController.wsc
@@ -1,0 +1,60 @@
+<?xml version="1.0"?>
+<!-- ===================================================== -->
+<!--  Copyright 2012, Analytical Graphics, Inc.            -->
+<!-- ===================================================== -->
+<component>
+	<?component error="true" debug="true"?>
+	<registration
+	    description="VBScript.ConstantRates.AttitudeController"
+	    progid="VBScript.ConstantRates.AttitudeController.WSC"
+	    version="1.00"
+	    classid="{137FEEA8-518B-4f31-A73A-93848F5E004E}"
+	/>
+	<public>
+
+		<!-- ========== -->
+		<!-- Properties -->
+		<!-- ========== -->
+		<property name="Name"		get="GetName"/>
+		<property name="Yaw" 		get="GetYaw" 		put="SetYaw"/>
+		<property name="YawRate" 	get="GetYawRate" 	put="SetYawRate"/>
+		<property name="Pitch" 		get="GetPitch" 		put="SetPitch"/>
+		<property name="PitchRate" 	get="GetPitchRate" 	put="SetPitchRate"/>
+		<property name="Roll" 		get="GetRoll" 		put="SetRoll"/>
+		<property name="RollRate" 	get="GetRollRate" 	put="SetRollRate"/>
+		<property name="RefAxes" 	get="GetRefAxes" 	put="SetRefAxes"/>
+
+		<!-- ======= -->
+		<!-- Methods -->
+		<!-- ======= -->
+		<method name="Init">
+			<parameter name="site"/>
+		</method>
+		<method name="PrePropagate">
+			<parameter name="result"/>
+		</method>
+		<method name="PreNextStep">
+			<parameter name="result"/>
+		</method>
+		<method name="Evaluate">
+			<parameter name="result"/>
+		</method>
+		<method name="PostPropagate">
+			<parameter name="result"/>
+		</method>
+		<method name="Free"/>
+		<method name="GetPluginConfig">
+			<parameter name="AgAttrBuilder"/>
+		</method>
+		<method name="VerifyPluginConfig">
+			<parameter name="AgUtPluginCfgVerifyResult"/>
+		</method>
+	</public>
+
+	<script language="VBScript" src="VBScript.ConstantRates.AttitudeController.vbs"/>
+
+</component>
+
+<!-- ===================================================== -->
+<!--  Copyright 2012, Analytical Graphics, Inc.            -->
+<!-- ===================================================== -->

--- a/StkUiPlugins/VB/Astrogator_ConstantThrustRampEngine/Constant Rate Engine Model.xml
+++ b/StkUiPlugins/VB/Astrogator_ConstantThrustRampEngine/Constant Rate Engine Model.xml
@@ -1,0 +1,48 @@
+<?xml version = "1.0"?>
+
+<!--
+      AGI Registry File for COM Servers. 
+-->
+
+<AGIRegistry version = "1.0">
+
+	<CategoryRegistry>
+		
+		<Category Name = "Engine Models">
+				
+			<!-- This tag to the left indicates the start of a comment block
+
+				Register your plugins with those below. Use the following format:
+
+				<Plugin DisplayName = "YOUR_NAME_TO_APPEAR_IN_USER_INTERFACE_GOES_HERE" ProgID = "YOUR_PROGID_GOES_HERE"/>
+
+				The tag below indicates the end of the comment block 
+			-->
+			
+			<!-- NOTE: The xml reader is case sensitive, so while the keyword ProgID is valid, 
+					   ProgId is invalid because of the 'd' not being capitalized. 
+					   Any improper keyword casing violation will cause the plugin to 
+					   not be registered.
+			-->
+
+            <!-- This section is a comment block.
+			
+			The following Plugin tags register each Plugin component as an Engine Model Plugin. 
+			
+			To enable one of the sample plugins in STK, simply build the component (if necessary), 
+			register it in the Windows Registry, and move the registration line below 
+			outside of this comment block.
+
+			<Plugin DisplayName = "JScript Engine Example" ProgID = "JScript.Example1.EngineModel.WSC"/>
+			<Plugin DisplayName = "CPP Engine Example" ProgID = "AGI.Astrogator.Plugin.Examples.EngineModeling.CPP.Example1"/>
+			<Plugin DisplayName = "CSharp Engine Example" ProgID = "AGI.Astrogator.Plugin.Examples.EngineModeling.CSharp.Example1"/>
+			<Plugin DisplayName = "Matlab Engine Example" ProgID = "Matlab.Example1.EngineModel.WSC"/>
+			
+             -->
+			<Plugin DisplayName = "VBScript Constant Thrust Rate Engine" ProgID = "VBScript.ConstantThrustRate.EngineModel.WSC"/>
+
+		</Category>
+		
+	</CategoryRegistry>
+
+</AGIRegistry>

--- a/StkUiPlugins/VB/Astrogator_ConstantThrustRampEngine/ReadMe.txt
+++ b/StkUiPlugins/VB/Astrogator_ConstantThrustRampEngine/ReadMe.txt
@@ -1,0 +1,6 @@
+This plugin created an engine model where the engine thrust scales linearly with time. 
+
+To use this plugin it must be registered using the following FAQ: https://agiweb.secure.force.com/faqs/articles/HowTo/Register-wsc-plugin
+
+Once registered, you will find the "VBScript Constant Thrust Rate Engine" in the "Engine Models" tab of the "Utilities". Open the properties
+of this engine model to edit the initial thrust, the thrust rate, and the mass flow rate of the engine. 

--- a/StkUiPlugins/VB/Astrogator_ConstantThrustRampEngine/VBScript.ConstantThrustRate.EngineModel.vbs
+++ b/StkUiPlugins/VB/Astrogator_ConstantThrustRampEngine/VBScript.ConstantThrustRate.EngineModel.vbs
@@ -1,0 +1,258 @@
+'======================================================
+'  Copyright 2012, Analytical Graphics, Inc.          
+' =====================================================
+
+'===========================================
+' AgEAttrAddFlags Enumeration
+'===========================================
+Dim eFlagNone, eFlagTransparent, eFlagHidden, eFlagTransient, eFlagReadOnly, eFlagFixed
+
+eFlagNone			= 0
+eFlagTransparent	= 2
+eFlagHidden			= 4
+eFlagTransient		= 8  
+eFlagReadOnly		= 16
+eFlagFixed			= 32
+
+'==================================
+' Log Msg Type Enumeration
+'==================================
+Dim eLogMsgDebug, eLogMsgInfo, eLogMsgForceInfo, eLogMsgWarning, eLogMsgAlarm
+
+eLogMsgDebug	 	= 0
+eLogMsgInfo 		= 1
+eLogMsgForceInfo 	= 2
+eLogMsgWarning 		= 3
+eLogMsgAlarm 		= 4
+
+'==========================================
+' AgETimeScale
+'==========================================
+Dim eSTKEpochSec
+eSTKEpochSec = 4
+
+'================================
+' Declare Global Variables
+'================================
+Dim m_AgUtPluginSite
+Dim m_AgAttrScope
+Dim m_InitTime
+Dim m_gatorPrv
+Dim m_argOfLat
+
+Set m_AgUtPluginSite = Nothing
+Set m_AgAttrScope	 = Nothing
+Set m_gatorPrv = Nothing
+Set m_argOfLat = Nothing
+
+'======================================
+' Declare Global 'Attribute' Variables
+'======================================
+Dim m_Name
+Dim m_Thrust
+Dim m_ThrustRate
+Dim m_MassFlowRate
+
+m_Name	= "VBScript.ConstantThrustRate.EngineModel.wsc"   
+m_Thrust	= 1000 'N
+m_ThrustRate	= 5 'N/s
+m_MassFlowRate  = 10 'kg/sec
+
+'=======================
+' GetPluginConfig method
+'=======================
+Function GetPluginConfig( AgAttrBuilder )
+
+	If( m_AgAttrScope is Nothing ) Then
+		'MsgBox "here1"
+		Set m_AgAttrScope = AgAttrBuilder.NewScope()
+		'MsgBox "here2"
+		
+		'===========================
+		' General Plugin attributes
+		'===========================
+		Call AgAttrBuilder.AddStringDispatchProperty( m_AgAttrScope, "PluginName", "Human readable plugin name or alias", "Name", eFlagReadOnly )
+		'MsgBox "here3"
+		'===========================
+		' Propagation related
+		'===========================
+		Call AgAttrBuilder.AddQuantityDispatchProperty2  ( m_AgAttrScope, "Thrust", "Initial Thrust", "Thrust", "ForceUnit", "Newtons", "Newtons", 0 )
+		Call AgAttrBuilder.AddQuantityDispatchProperty2  ( m_AgAttrScope, "ThrustRate", "Thrust Rate (per sec)", "ThrustRate", "ForceUnit", "Newtons", "Newtons", 0 )
+		Call AgAttrBuilder.AddQuantityDispatchProperty2  ( m_AgAttrScope, "MassFlowRate", "Mass Flow Rate (kg/sec)", "MassFlowRate", "MassUnit", "Kilograms", "Kilograms", 0 )
+	End If
+
+	Set GetPluginConfig = m_AgAttrScope
+
+End Function  
+
+'===========================
+' VerifyPluginConfig method
+'===========================
+Function VerifyPluginConfig(AgUtPluginConfigVerifyResult)
+   
+    Dim Result
+    Dim Message
+
+	Result = true
+	Message = "Ok"
+
+	AgUtPluginConfigVerifyResult.Result  = Result
+	AgUtPluginConfigVerifyResult.Message = Message
+
+End Function  
+
+'===========================
+' Message method
+'===========================
+Sub Message( msgType, msg )
+   
+	If( Not m_AgUtPluginSite is Nothing) then
+	   	
+		Call m_AgUtPluginSite.Message( msgType, msg )
+
+	End If
+   	
+End Sub
+
+'======================
+' Init Method
+'======================
+Function Init( AgUtPluginSite )
+
+	Init = 1
+    
+End Function
+
+'======================
+' PrePropagate Method
+'======================
+Function PrePropagate( AgGatorPluginResultEvalEngineModel )
+
+	If( Not AgGatorPluginResultEvalEngineModel is Nothing) then
+
+		Dim dcArray
+		dcArray = AgGatorPluginResultEvalEngineModel.DayCount_Array( eStkEpochSec )
+		If(IsArray(dcArray) and UBound(dcArray) > 0) Then
+ 			m_InitTime = dcArray(0) * 86400.0 + dcArray(1)
+ 		End If
+ 		
+	End If
+
+	PrePropagate = 1
+
+End Function
+
+'======================
+' PreNextStep Function
+'======================
+Function PreNextStep( AgGatorPluginResultEvalEngineModel )
+
+	PreNextStep = 1
+	
+End Function
+
+'=================
+' Evaluate Method
+'=================
+Function Evaluate( AgGatorPluginResultEvalEngineModel )
+
+	If( Not AgGatorPluginResultEvalEngineModel is Nothing) then
+         
+			Dim time
+			Dim Thrust
+			Dim deltaT
+			Dim dcArray
+			time = m_InitTime
+			
+			dcArray = AgGatorPluginResultEvalEngineModel.DayCount_Array( eStkEpochSec )
+			If(IsArray(dcArray) and UBound(dcArray) > 0) Then
+ 				time = dcArray(0) * 86400.0 + dcArray(1)
+ 			End If
+			
+			deltaT = time - m_InitTime
+						
+			Thrust = m_Thrust + m_ThrustRate * deltaT
+					
+			Call AgGatorPluginResultEvalEngineModel.SetThrustAndMassFlowRate(Thrust, m_MassFlowRate)
+			
+		End If
+         
+        Evaluate = 1
+
+End Function
+
+'======================
+' PostPropagate Method
+'======================
+Function PostPropagate(resultInterface)
+      
+	PostPropagate = 0
+       	
+End Function
+
+'=================
+' Free Method
+'=================
+Sub Free()
+
+	' do nothing
+        
+End Sub
+    
+'==================
+' Name property
+'==================
+Function GetName()
+
+	GetName = m_Name
+
+End function
+
+'==================
+' Thrust property
+'==================
+Function GetThrust()
+
+       GetThrust = m_Thrust
+
+End Function
+
+Function SetThrust( thrust )
+
+       m_Thrust = thrust
+
+End Function
+
+'==================
+' ThrustRate property
+'==================
+Function GetThrustRate()
+
+       GetThrustRate = m_ThrustRate
+
+End Function
+
+Function SetThrustRate( thrustRate )
+
+       m_ThrustRate = thrustRate
+
+End Function
+
+'==================
+' MassFlowRate property
+'==================
+Function GetMassFlowRate()
+
+       GetMassFlowRate = m_MassFlowRate
+
+End Function
+
+Function SetMassFlowRate( massFlowRate )
+
+       m_MassFlowRate = massFlowRate
+
+End Function
+
+'======================================================
+'  Copyright 2012, Analytical Graphics, Inc.          
+' =====================================================

--- a/StkUiPlugins/VB/Astrogator_ConstantThrustRampEngine/VBScript.ConstantThrustRate.EngineModel.wsc
+++ b/StkUiPlugins/VB/Astrogator_ConstantThrustRampEngine/VBScript.ConstantThrustRate.EngineModel.wsc
@@ -1,0 +1,56 @@
+<?xml version="1.0"?>
+<!-- ===================================================== -->
+<!--  Copyright 2012, Analytical Graphics, Inc.            -->
+<!-- ===================================================== -->
+<component>
+	<?component error="true" debug="true"?>
+	<registration
+	    description="VBScript.ConstantThrustRate.EngineModel"
+	    progid="VBScript.ConstantThrustRate.EngineModel.WSC"
+	    version="1.00"
+	    classid="{F8B289DF-EAC4-418a-BB43-0213DEE8B96C}"
+	/>
+	<public>
+
+		<!-- ========== -->
+		<!-- Properties -->
+		<!-- ========== -->
+		<property name="Name"	get="GetName"/>
+		<property name="Thrust"	get="GetThrust"	put="SetThrust"/>
+		<property name="ThrustRate"    	get="GetThrustRate"    	put="SetThrustRate"/>
+		<property name="MassFlowRate" 	get="GetMassFlowRate" 	put="SetMassFlowRate"/>
+
+		<!-- ======= -->
+		<!-- Methods -->
+		<!-- ======= -->
+		<method name="Init">
+			<parameter name="site"/>
+		</method>
+		<method name="PrePropagate">
+			<parameter name="result"/>
+		</method>
+		<method name="PreNextStep">
+			<parameter name="result"/>
+		</method>
+		<method name="Evaluate">
+			<parameter name="result"/>
+		</method>
+		<method name="PostPropagate">
+			<parameter name="result"/>
+		</method>
+		<method name="Free"/>
+		<method name="GetPluginConfig">
+			<parameter name="AgAttrBuilder"/>
+		</method>
+		<method name="VerifyPluginConfig">
+			<parameter name="AgUtPluginCfgVerifyResult"/>
+		</method>
+	</public>
+
+	<script language="VBScript" src="VBScript.ConstantThrustRate.EngineModel.vbs"/>
+
+</component>
+
+<!-- ===================================================== -->
+<!--  Copyright 2012, Analytical Graphics, Inc.            -->
+<!-- ===================================================== -->


### PR DESCRIPTION
Constant attitude rate plugin allows users to specify constant slew rates in YPR axes that will execute during finite astrogator maneuvers. Constant thrust ramp engine plugin creates an engine model in which the thrust output of the engine varies linearly with time.