### PR TITLE
Fix start time rounding error

### DIFF
--- a/StkUiPlugins/CSharp/HorizonsEphemImporter/Stk12.UiPlugin.HorizonsEphemImporter/Stk12.UiPlugin.HorizonsEphemImporter/ImporterGUI.cs
+++ b/StkUiPlugins/CSharp/HorizonsEphemImporter/Stk12.UiPlugin.HorizonsEphemImporter/Stk12.UiPlugin.HorizonsEphemImporter/ImporterGUI.cs
@@ -129,13 +129,10 @@ namespace Stk12.UiPlugin.HorizonsEphemImporter
                 string bodyName = rxName.Match(lastLine).Value;
 
                 // Extract ephemeris start time in Horizons database.
-                // Because Horizons returns a time to 4 decimal places but inputs are only allowed to be 3 digits, we round to the nearest thousandth.
+                // Because Horizons returns a time to 4 decimal places but inputs are only allowed to be 3 digits, we round up to the nearest thousandth.
                 Regex rxStartEnd = new Regex(@"(A.D.|B.C.).*(?=\s)");
                 minStart = rxStartEnd.Match(lastLine).Value;
-                if (int.Parse(minStart.Substring(minStart.Length - 1, 1)) >= 5)
-                    minStart = minStart.Substring(0, minStart.Length - 2) + (int.Parse(minStart.Substring(minStart.Length - 2, 1)) + 1).ToString();
-                else
-                    minStart = minStart.Substring(0, minStart.Length - 2) + int.Parse(minStart.Substring(minStart.Length - 2, 1)).ToString();
+                minStart = minStart.Substring(0, minStart.Length - 2) + (int.Parse(minStart.Substring(minStart.Length - 2, 1)) + 1).ToString();
 
                 // Query again using new minStart time to get the error that returns the max stop time for the ephemeris
                 using (StreamReader objReader = queryHorizons(minStart, maxStop, "1 d"))

--- a/StkUiPlugins/CSharp/HorizonsEphemImporter/Stk12.UiPlugin.HorizonsEphemImporter/Stk12.UiPlugin.HorizonsEphemImporter/Stk12.UiPlugin.HorizonsEphemImporter.csproj
+++ b/StkUiPlugins/CSharp/HorizonsEphemImporter/Stk12.UiPlugin.HorizonsEphemImporter/Stk12.UiPlugin.HorizonsEphemImporter/Stk12.UiPlugin.HorizonsEphemImporter.csproj
@@ -34,27 +34,25 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="AGI.STKObjects.Interop">
-      <HintPath>..\..\..\..\..\..\Program Files\AGI\STK 12\bin\Primary Interop Assemblies\AGI.STKObjects.Interop.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\..\..\..\..\Program Files\AGI\STK 12\bin\Primary Interop Assemblies\AGI.STKObjects.Interop.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="AGI.Ui.Application.Interop">
-      <HintPath>..\..\..\..\..\..\Program Files\AGI\STK 12\bin\Primary Interop Assemblies\AGI.Ui.Application.Interop.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\..\..\..\..\Program Files\AGI\STK 12\bin\Primary Interop Assemblies\AGI.Ui.Application.Interop.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="AGI.Ui.Core.Interop">
-      <HintPath>..\..\..\..\..\..\Program Files\AGI\STK 12\bin\Primary Interop Assemblies\AGI.Ui.Core.Interop.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\..\..\..\..\Program Files\AGI\STK 12\bin\Primary Interop Assemblies\AGI.Ui.Core.Interop.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="AGI.Ui.Plugins.Interop">
-      <HintPath>..\..\..\..\..\..\Program Files\AGI\STK 12\bin\Primary Interop Assemblies\AGI.Ui.Plugins.Interop.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\..\..\..\..\Program Files\AGI\STK 12\bin\Primary Interop Assemblies\AGI.Ui.Plugins.Interop.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="stdole, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <SpecificVersion>False</SpecificVersion>
       <EmbedInteropTypes>True</EmbedInteropTypes>
-      <HintPath>..\..\..\..\..\..\Program Files\AGI\STK 12\bin\stdole.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
Since the API returns 4 decimal places but only allows inputs for 3 decimal places, an ephemeris availability error can sometimes be introduced if rounding down. This change forces ephemeris start times to always round up.

## Describe the changes in this pull request

## Checklist before requesting a review
- [x] Did you update the proper readme file?
- [x] Did you list any dependencies in the readme?
- [x] Is there a scenario that you need to link to?