### PR TITLE
Fixed version check for STK metadata extractor

### DIFF
--- a/StkEngineApplications/CSharp/StkMetaDataExtractor/Stk12.StkMetadataExtrator/StkMetadataExtractor.cs
+++ b/StkEngineApplications/CSharp/StkMetaDataExtractor/Stk12.StkMetadataExtrator/StkMetadataExtractor.cs
@@ -67,7 +67,7 @@ namespace StkMetadataExtractor
             var versionInts = version.Split('.').Select(int.Parse).ToList();
 
             // 12.0.0 doesn't support Cesium Export so if that's what you have, skip the czml export
-            if (versionInts[0] >= 12 && versionInts[1] >= 0 && versionInts[2] > 0)
+            if (versionInts[0] >= 12 && !version.Equals("12.0.0"))
             {
                 var outputCzmlPath = Path.Combine(outputDirectory,
                     Path.GetFileName(Path.ChangeExtension(scenarioFilePath, ".czml")));


### PR DESCRIPTION
Previous "if" condition excluded all STK 12 versions that had a maintenance version of 0 from generating a .czml file. This was blocking STK 12.10.0, for example. Just need to exclude 12.0.0 specifically.